### PR TITLE
Literal on step 3 example code

### DIFF
--- a/suggest.rst
+++ b/suggest.rst
@@ -89,7 +89,7 @@ Modify the Handheld Activity
 
   .. code-block:: java
 	  
-    NotificationCompat.Builder notificationBuilder =
+    Notification notification =
       new NotificationCompat.Builder(this)
          .setSmallIcon(R.drawable.ic_launcher)
           .setContentTitle("Hello Android Wear")


### PR DESCRIPTION
When following your tutorial, found a literal on step 3 for "Android Wear Suggest" Chapter. 
NotificationCompat.Builder(this).....build() returns a Notification instead of a Builder instance.
